### PR TITLE
FEATURE: Show cache hits and uncached segments

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,4 @@
+root = true
+
+[*.js]
+indent_size = 2

--- a/Classes/Aspect/CollectDebugInformationAspect.php
+++ b/Classes/Aspect/CollectDebugInformationAspect.php
@@ -43,9 +43,9 @@ class CollectDebugInformationAspect
     protected $contentCacheHits = 0;
 
     /**
-     * @var int
+     * @var array
      */
-    protected $contentCacheMisses = 0;
+    protected $contentCacheMisses = [];
 
     /**
      * @Flow\Pointcut("setting(t3n.Neos.Debug.enabled)")
@@ -103,14 +103,17 @@ class CollectDebugInformationAspect
     }
 
     /**
-     * @Flow\AfterReturning("method(Neos\Fusion\Core\Cache\ContentCache->getCachedSegment()) && t3n\Neos\Debug\Aspect\CollectDebugInformationAspect->debuggingActive")
+     * @Flow\Around("method(Neos\Fusion\Core\Cache\ContentCache->getCachedSegment()) && t3n\Neos\Debug\Aspect\CollectDebugInformationAspect->debuggingActive")
      */
-    public function addCacheMiss(\Neos\Flow\AOP\JoinPointInterface $joinPoint): void
+    public function addCacheMiss(\Neos\Flow\AOP\JoinPointInterface $joinPoint)
     {
-        $result = $joinPoint->getResult();
+        $fusionPath = $joinPoint->getMethodArgument('fusionPath');
+
+        $result = $joinPoint->getAdviceChain()->proceed($joinPoint);
         if ($result === false) {
-            $this->contentCacheMisses++;
+            $this->contentCacheMisses[]= $fusionPath;
         }
+        return $result;
     }
 
     /**

--- a/Classes/Aspect/ContentCacheSegmentAspect.php
+++ b/Classes/Aspect/ContentCacheSegmentAspect.php
@@ -165,7 +165,7 @@ class ContentCacheSegmentAspect
             + ['fusionObject' => ObjectAccess::getProperty($this->interceptedFusionObject, 'fusionObjectName', true)]
             + array_slice($info, $injectPosition, count($info) - $injectPosition, true);
 
-        $info['created'] = (new \DateTime())->format('d.m.Y H:i:s');
+        $info['created'] = (new \DateTime())->format(DATE_W3C);
 
         $cCacheDebugData = '<!--__T3N_CONTENT_CACHE_DEBUG__ ' . json_encode($info) . ' -->';
 

--- a/Resources/Public/Script/main.js
+++ b/Resources/Public/Script/main.js
@@ -35,6 +35,19 @@ window.__enable_neos_debug__ = (setCookie = false) => {
   }
   debugInfos.cCacheUncached = 0;
 
+  // Takes an ISO time and returns a string representing how
+  // long ago the date represents.
+  function prettyDate(time) {
+    var date = new Date((time || "").replace(/-/g, "/").replace(/[TZ]/g, " ")),
+      diff = (((new Date()).getTime() - date.getTime()) / 1000),
+      day_diff = Math.floor(diff / 86400);
+
+    if (isNaN(day_diff) || day_diff < 0 || day_diff >= 31) return;
+
+    return day_diff === 0 && (
+      diff < 60 && "just now" || diff < 120 && "1 minute ago" || diff < 3600 && Math.floor(diff / 60) + " minutes ago" || diff < 7200 && "1 hour ago" || diff < 86400 && Math.floor(diff / 3600) + " hours ago") || day_diff === 1 && "Yesterday" || day_diff < 7 && day_diff + " days ago" || day_diff < 31 && Math.ceil(day_diff / 7) + " weeks ago";
+  }
+
   const infoElements = [];
   const createInfoElement = ({ parentNode, cacheInfo, index }) => {
     if (cacheInfo.mode === 'uncached') {
@@ -57,6 +70,7 @@ window.__enable_neos_debug__ = (setCookie = false) => {
 
     const clone = parentNode.cloneNode();
     clone.innerHTML = '';
+    cacheInfo['created'] = new Date(cacheInfo['created']).toLocaleString() + (cacheInfo['mode'] !== 'uncached' ? ' - ' + prettyDate(cacheInfo['created']) : '');
     cacheInfo['markup'] =
       clone.outerHTML
         .replace(/<\/.+/, '')

--- a/Resources/Public/Script/main.js
+++ b/Resources/Public/Script/main.js
@@ -29,13 +29,18 @@ window.__enable_neos_debug__ = (setCookie = false) => {
   // parse debug values
   const debugValuesWalker = document.createTreeWalker(document.getRootNode(), NodeFilter.SHOW_COMMENT, node => (node.nodeValue.indexOf(DEBUG_PREFIX) === 0 ? NodeFilter.FILTER_ACCEPT : NodeFilter.FILTER_SKIP), false);
   const dataNode = debugValuesWalker.nextNode();
-  let debugInfos = [];
+  let debugInfos = {};
   if (dataNode) {
     debugInfos = JSON.parse(dataNode.nodeValue.substring(DEBUG_PREFIX.length));
   }
+  debugInfos.cCacheUncached = 0;
 
   const infoElements = [];
   const createInfoElement = ({ parentNode, cacheInfo, index }) => {
+    if (cacheInfo.mode === 'uncached') {
+        debugInfos.cCacheUncached++;
+    }
+
     const container = document.createElement('div');
     container.classList.add('t3n__content-cache-debug-container');
 
@@ -255,14 +260,14 @@ window.__enable_neos_debug__ = (setCookie = false) => {
     container.classList.add('t3n__content-cache-debug-modal');
 
     const cacheLegend = document.createElement('div');
-    cacheLegend.innerHTML = `<h3>Cache Information</h3><div class="debug-meta"><div><p>Hits: ${debugInfos.cCacheHits}</p></div><div><p>Misses: ${debugInfos.cCacheMisses}</p></div></div>`;
+    cacheLegend.innerHTML = `<h3>Cache Information</h3><div class="debug-meta"><div><p>Hits: ${debugInfos.cCacheHits}</p></div><div><p>Misses: ${debugInfos.cCacheMisses.length}</p></div><div><p>Uncached: ${debugInfos.cCacheUncached}</p></div></div>`;
     container.appendChild(cacheLegend);
 
     const infoTable = document.createElement('table');
     infoTable.classList.add('t3n__debug-info-table');
 
     const headRow = document.createElement('tr');
-    headRow.innerHTML = '<th>Mode</th><th>Fusion path</th><th>';
+    headRow.innerHTML = '<th>Mode</th><th>Cache hit</th><th>Fusion path</th><th>';
     infoTable.appendChild(headRow);
 
     infoElements.forEach(({ cacheInfo, table, show }) => {
@@ -270,7 +275,7 @@ window.__enable_neos_debug__ = (setCookie = false) => {
       detailRow.classList.add('detail-row');
 
       const detailCell = document.createElement('td');
-      detailCell.setAttribute('colspan', 3);
+      detailCell.setAttribute('colspan', 4);
 
       // we clone the node so the inspect button won't trigger the remove on this table
       detailCell.appendChild(table.cloneNode(true));
@@ -279,7 +284,11 @@ window.__enable_neos_debug__ = (setCookie = false) => {
 
       const row = document.createElement('tr');
       const fusionPath = cacheInfo.fusionPath.replace(/\//g, '<i>/</i>').replace(/<([^>\/]{2,})>/g, '<span class="fusion-prototype"><span>$1</span></span>');
-      row.innerHTML = `<td class="${cacheInfo.mode}">${cacheInfo.mode}</td><td>${fusionPath}</td>`;
+      const cacheHit = !debugInfos.cCacheMisses.includes(cacheInfo.fusionPath) && cacheInfo.mode !== 'uncached';
+
+      row.innerHTML = `<td class="${cacheInfo.mode}">${cacheInfo.mode}</td>`;
+      row.innerHTML += `<td class="${cacheHit ? 'cached' : 'uncached'}">${cacheHit ? 'yes' : 'no'}</td>`;
+      row.innerHTML += `<td>${fusionPath}</td>`;
 
       const actions = document.createElement('td');
       const togglePrototype = document.createElement('button');
@@ -373,7 +382,7 @@ window.__enable_neos_debug__ = (setCookie = false) => {
 
   const listButton = document.createElement('span');
   if (debugInfos.cCacheHits || debugInfos.cCacheMisses) {
-    listButton.innerText = `⚡️ Cache (hits: ${debugInfos.cCacheHits}, misses: ${debugInfos.cCacheMisses})`;
+    listButton.innerText = `⚡️ Cache (hits: ${debugInfos.cCacheHits}, misses: ${debugInfos.cCacheMisses.length}, uncached ${debugInfos.cCacheUncached})`;
   } else {
     listButton.innerText = '️⚡️Cache';
   }


### PR DESCRIPTION
With this change the Cache table shows individual hits and misses for the entries.
Also the number of uncached segments is added to the hit/miss views.

Additionally the creation date is now formatted on the client to match
their locale and also shows the relative date.

<img width="823" alt="Bildschirmfoto 2020-08-18 um 08 14 07" src="https://user-images.githubusercontent.com/596967/90476971-cb113500-e12a-11ea-8f02-bf77448c662e.png">
