### PR TITLE
FEATURE: Show fusion path in entry identifier list

### DIFF
--- a/Classes/Aspect/ContentCacheSegmentAspect.php
+++ b/Classes/Aspect/ContentCacheSegmentAspect.php
@@ -141,6 +141,7 @@ class ContentCacheSegmentAspect
      */
     public function interceptContentCacheEntryIdentifier(JoinPointInterface $joinPoint): string
     {
+        $fusionPath = $joinPoint->getMethodArgument('fusionPath');
         $cacheIdentifierValues = $joinPoint->getMethodArgument('cacheIdentifierValues');
         $this->interceptedCacheEntryValues = [];
 
@@ -153,6 +154,7 @@ class ContentCacheSegmentAspect
         }
 
         $result = $joinPoint->getAdviceChain()->proceed($joinPoint);
+        $this->interceptedCacheEntryValues['[fusionPath]'] = htmlspecialchars($fusionPath);
         $this->interceptedCacheEntryValues['=> hashed identifier'] = $result;
         return $result;
     }

--- a/Resources/Public/Style/main.css
+++ b/Resources/Public/Style/main.css
@@ -54,6 +54,13 @@
   grid-gap: .2rem .5rem;
 }
 
+.t3n__content-cache-debug-table .object-values span {
+  max-width: 90%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .t3n__content-cache-debug-table i {
   font-style: normal;
   font-weight: bold;


### PR DESCRIPTION
This change makes it more obvious that the Fusion path of a cached block is part of the entry identifiers.
Including the prototype names. 
The currently shown fusion path is shortened for readability and hides the different prototypes.
Additionally one can only know that the fusion path is part of the entry identifier when looking into the
PHP implementation of the ContentCache.

Resolves: #122

<img width="1068" alt="Bildschirmfoto 2020-12-17 um 10 21 45" src="https://user-images.githubusercontent.com/596967/102468330-ab930600-4051-11eb-9d21-d627f42a5f1c.png">