### PR TITLE
BUGFIX: Measure server timing again

### DIFF
--- a/Classes/Http/Middleware/AddServerTimingMiddleware.php
+++ b/Classes/Http/Middleware/AddServerTimingMiddleware.php
@@ -49,6 +49,7 @@ class AddServerTimingMiddleware implements MiddlewareInterface
         }
 
         $serverTiming = '';
+        $this->debugService->setStartRequestAt($request->getAttribute(MeasureServerTimingMiddleware::TIMING_ATTRIBUTE));
         $metrics = $this->debugService->getMetrics();
         foreach ($metrics as $key => ['value' => $value, 'description' => $description]) {
             $serverTiming .= ($serverTiming ? ', ' : '') . $key;

--- a/Classes/Http/Middleware/MeasureServerTimingMiddleware.php
+++ b/Classes/Http/Middleware/MeasureServerTimingMiddleware.php
@@ -23,6 +23,8 @@ use t3n\Neos\Debug\Service\DebugService;
 
 class MeasureServerTimingMiddleware implements MiddlewareInterface
 {
+    public const TIMING_ATTRIBUTE = 't3nNeosDebugTimingStart';
+
     /**
      * @Flow\InjectConfiguration(path="serverTimingHeader.enabled")
      *
@@ -39,10 +41,11 @@ class MeasureServerTimingMiddleware implements MiddlewareInterface
 
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
-        $response = $handler->handle($request);
-
         if ($this->enabled) {
-            $this->debugService->startRequestTimer();
+            $timerStart = $this->debugService->startRequestTimer();
+            $response = $handler->handle($request->withAttribute(self::TIMING_ATTRIBUTE, $timerStart));
+        } else {
+            $response = $handler->handle($request);
         }
 
         return $response;

--- a/Classes/Service/DebugService.php
+++ b/Classes/Service/DebugService.php
@@ -22,12 +22,12 @@ use Neos\Flow\Annotations as Flow;
 class DebugService
 {
     /**
-     * @var int
+     * @var float
      */
     protected $startRequestAt;
 
     /**
-     * @var int
+     * @var float
      */
     protected $stopRequestAt;
 
@@ -39,9 +39,17 @@ class DebugService
     /**
      * Starts the timer for the request process
      */
-    public function startRequestTimer(): void
+    public function startRequestTimer(): float
     {
-        $this->startRequestAt = microtime(true) * 1000;
+        return $this->startRequestAt = microtime(true) * 1000;
+    }
+
+    /**
+     * Sets the starttime of the request
+     */
+    public function setStartRequestAt(float $startRequestAt): void
+    {
+        $this->startRequestAt = $startRequestAt;
     }
 
     /**

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -20,10 +20,10 @@ Neos:
     http:
       middlewares:
         t3n.Neos.Debug:MeasureServerTiming:
-          position: 'start'
+          position: 'start 999'
           middleware: 't3n\Neos\Debug\Http\Middleware\MeasureServerTimingMiddleware'
         t3n.Neos.Debug:AddServerTimingHeader:
-          position: 'after dispatch'
+          position: 'before dispatch 999'
           middleware: 't3n\Neos\Debug\Http\Middleware\AddServerTimingMiddleware'
 
     reflection:


### PR DESCRIPTION
Due to the switch to middlewares the start variable was not persisted until the end of the request.
Also due to a configuration mistake the finalising middleware was never triggered.