### PR TITLE
BUGFIX: Prevent empty response for non html formats

### DIFF
--- a/Classes/Aspect/CollectDebugInformationAspect.php
+++ b/Classes/Aspect/CollectDebugInformationAspect.php
@@ -110,6 +110,7 @@ class CollectDebugInformationAspect
 
         if ($response instanceof Response) {
             $output = $response->getBody()->getContents();
+            $response->getBody()->rewind();
 
             if ($response->getHeader('Content-Type') !== 'text/html'
                 && strpos($output, '<!DOCTYPE html>') === false) {


### PR DESCRIPTION
In cases of non html responses like the `/sitemap.xml` the content stream was retrieved but then the pointer of the stream is already at the end.
This resulted in an empty broken response.