### PR TITLE
Support plain fusion view

### DIFF
--- a/Classes/Aspect/CollectDebugInformationAspect.php
+++ b/Classes/Aspect/CollectDebugInformationAspect.php
@@ -80,7 +80,8 @@ class CollectDebugInformationAspect
 
     /**
      * @Flow\Around("method(Neos\Neos\View\FusionView->render()) && t3n\Neos\Debug\Aspect\CollectDebugInformationAspect->debuggingActive")
-     *
+     * @Flow\Around("method(Neos\Fusion\View\FusionView->render()) && t3n\Neos\Debug\Aspect\CollectDebugInformationAspect->debuggingActive")
+     * 
      * @param \Neos\Flow\AOP\JoinPointInterface $joinPoint
      *
      * @return string|Response


### PR DESCRIPTION
Collect debug information in fusion view to support flow projects with fusion rendering

Note: In this case Styles and Scripts have to be added manually to your rendering when Neos.Neos:Page is not used.