### PR TITLE
BUGFIX: prevent invalid return type error

### DIFF
--- a/Classes/Aspect/ContentCacheSegmentAspect.php
+++ b/Classes/Aspect/ContentCacheSegmentAspect.php
@@ -69,8 +69,10 @@ class ContentCacheSegmentAspect
 
     /**
      * @Flow\Around("method(Neos\Fusion\Core\Cache\ContentCache->createCacheSegment()) && t3n\Neos\Debug\Aspect\ContentCacheSegmentAspect->debuggingActive")
+     *
+     * @return mixed
      */
-    public function wrapCachedSegment(JoinPointInterface $joinPoint): string
+    public function wrapCachedSegment(JoinPointInterface $joinPoint)
     {
         $segment = $joinPoint->getAdviceChain()->proceed($joinPoint);
         $fusionPath = $joinPoint->getMethodArgument('fusionPath');
@@ -88,8 +90,10 @@ class ContentCacheSegmentAspect
 
     /**
      * @Flow\Around("method(Neos\Fusion\Core\Cache\RuntimeContentCache->evaluateUncached()) && t3n\Neos\Debug\Aspect\ContentCacheSegmentAspect->debuggingActive")
+     *
+     * @return mixed
      */
-    public function wrapEvaluateUncached(JoinPointInterface $joinPoint): string
+    public function wrapEvaluateUncached(JoinPointInterface $joinPoint)
     {
         $start = microtime(true);
         $segment = $joinPoint->getAdviceChain()->proceed($joinPoint);
@@ -106,8 +110,10 @@ class ContentCacheSegmentAspect
 
     /**
      * @Flow\Around("method(Neos\Fusion\Core\Cache\ContentCache->createUncachedSegment()) && t3n\Neos\Debug\Aspect\ContentCacheSegmentAspect->debuggingActive")
+     *
+     * @return mixed
      */
-    public function wrapUncachedSegment(JoinPointInterface $joinPoint): string
+    public function wrapUncachedSegment(JoinPointInterface $joinPoint)
     {
         $segment = $joinPoint->getAdviceChain()->proceed($joinPoint);
 
@@ -120,8 +126,10 @@ class ContentCacheSegmentAspect
 
     /**
      * @Flow\Around("method(Neos\Fusion\Core\Cache\ContentCache->createDynamicCachedSegment()) && t3n\Neos\Debug\Aspect\ContentCacheSegmentAspect->debuggingActive")
+     *
+     * @return mixed
      */
-    public function wrapDynamicSegment(JoinPointInterface $joinPoint): string
+    public function wrapDynamicSegment(JoinPointInterface $joinPoint)
     {
         $segment = $joinPoint->getAdviceChain()->proceed($joinPoint);
 
@@ -170,8 +178,10 @@ class ContentCacheSegmentAspect
     /**
      * @param mixed $segment This is mixed as the RuntimeContentCache might also return none string values
      * @param mixed[] $info
+     *
+     * @return mixed
      */
-    protected function renderCacheInfoIntoSegment($segment, array $info): string
+    protected function renderCacheInfoIntoSegment($segment, array $info)
     {
         $injectPosition = 2;
         $info = array_slice($info, 0, $injectPosition, true)

--- a/Classes/Aspect/ContentCacheSegmentAspect.php
+++ b/Classes/Aspect/ContentCacheSegmentAspect.php
@@ -69,10 +69,8 @@ class ContentCacheSegmentAspect
 
     /**
      * @Flow\Around("method(Neos\Fusion\Core\Cache\ContentCache->createCacheSegment()) && t3n\Neos\Debug\Aspect\ContentCacheSegmentAspect->debuggingActive")
-     *
-     * @return mixed
      */
-    public function wrapCachedSegment(JoinPointInterface $joinPoint)
+    public function wrapCachedSegment(JoinPointInterface $joinPoint): string
     {
         $segment = $joinPoint->getAdviceChain()->proceed($joinPoint);
         $fusionPath = $joinPoint->getMethodArgument('fusionPath');
@@ -91,7 +89,7 @@ class ContentCacheSegmentAspect
     /**
      * @Flow\Around("method(Neos\Fusion\Core\Cache\RuntimeContentCache->evaluateUncached()) && t3n\Neos\Debug\Aspect\ContentCacheSegmentAspect->debuggingActive")
      *
-     * @return mixed
+     * @return mixed the result of uncached segments might not be of type string, so we cannot define the return type
      */
     public function wrapEvaluateUncached(JoinPointInterface $joinPoint)
     {
@@ -110,10 +108,8 @@ class ContentCacheSegmentAspect
 
     /**
      * @Flow\Around("method(Neos\Fusion\Core\Cache\ContentCache->createUncachedSegment()) && t3n\Neos\Debug\Aspect\ContentCacheSegmentAspect->debuggingActive")
-     *
-     * @return mixed
      */
-    public function wrapUncachedSegment(JoinPointInterface $joinPoint)
+    public function wrapUncachedSegment(JoinPointInterface $joinPoint): string
     {
         $segment = $joinPoint->getAdviceChain()->proceed($joinPoint);
 
@@ -126,10 +122,8 @@ class ContentCacheSegmentAspect
 
     /**
      * @Flow\Around("method(Neos\Fusion\Core\Cache\ContentCache->createDynamicCachedSegment()) && t3n\Neos\Debug\Aspect\ContentCacheSegmentAspect->debuggingActive")
-     *
-     * @return mixed
      */
-    public function wrapDynamicSegment(JoinPointInterface $joinPoint)
+    public function wrapDynamicSegment(JoinPointInterface $joinPoint): string
     {
         $segment = $joinPoint->getAdviceChain()->proceed($joinPoint);
 
@@ -179,7 +173,7 @@ class ContentCacheSegmentAspect
      * @param mixed $segment This is mixed as the RuntimeContentCache might also return none string values
      * @param mixed[] $info
      *
-     * @return mixed
+     * @return mixed the cached data might not be of type string, so we cannot define the return type
      */
     protected function renderCacheInfoIntoSegment($segment, array $info)
     {


### PR DESCRIPTION
Removes most of the fixed return types inside the `ContentCacheSegmentAspect` class, as proposed in the linked issue.

Fixes #168 