### PR TITLE
TASK: Append cookie to all same-site requests (samesite: lax)

### DIFF
--- a/Resources/Public/Script/main.js
+++ b/Resources/Public/Script/main.js
@@ -4,7 +4,7 @@ window.__enable_neos_debug__ = (setCookie = false) => {
   }
 
   if (setCookie) {
-    document.cookie = '__neos_debug__=true;path=/';
+    document.cookie = '__neos_debug__=true;path=/;samesite=lax';
   }
 
   console.log('%c Starting Neos Debug Tool ... ', 'color: white; background: #f9423a; line-height: 20px; font-weight: bold');
@@ -424,7 +424,7 @@ window.__enable_neos_debug__ = (setCookie = false) => {
     infoVisible && infoElements.forEach(e => e.hide());
     listVisible && cacheTable.hide();
     window.__enable_neos_debug__.active = false;
-    document.cookie = '__neos_debug__=; expires=Thu, 01 Jan 1970 00:00:00 UTC;path=/';
+    document.cookie = '__neos_debug__=; expires=Thu, 01 Jan 1970 00:00:00 UTC;path=/;samesite=lax';
     console.log('%c Closing Neos Debug Tool> ', 'color: white; background: #f9423a; line-height: 20px; font-weight: bold');
   });
 


### PR DESCRIPTION
This is the default behavior of Flow and modern browsers, but browsers complain if it is not explicitly set.

This is the warning in Firefox 102:
---
Cookie “__neos_debug__” does not have a proper “SameSite” attribute value. Soon, cookies without the “SameSite” attribute or with an invalid value will be treated as “Lax”. This means that the cookie will no longer be sent in third-party contexts. If your application depends on this cookie being available in such contexts, please add the “SameSite=None“ attribute to it. To know more about the “SameSite“ attribute, read
https://developer.mozilla.org/docs/Web/HTTP/Headers/Set-Cookie/SameSite ---